### PR TITLE
Remove filter-menu class from side navigation

### DIFF
--- a/themes/vocabulary_theme/templates/blog-category.html
+++ b/themes/vocabulary_theme/templates/blog-category.html
@@ -12,7 +12,7 @@
 </header>
 
 <aside class="sidebar">
-  <nav class="filter-menu" aria-labelledby="categories">
+  <nav aria-labelledby="categories">
     <h2>Categories</h2>
     {{ render_categories(this.parent) }}
   </nav>

--- a/themes/vocabulary_theme/templates/page-with-toc.html
+++ b/themes/vocabulary_theme/templates/page-with-toc.html
@@ -10,7 +10,7 @@
 
 <aside class="sidebar">
     {% if this.is_child_of('/contributing-code') %}
-        <nav class="filter-menu" aria-labelledby="contributing-code">
+        <nav aria-labelledby="contributing-code">
             <h2>Contributing Code</h2>
             <ul>
                 {% for href, title in [
@@ -46,7 +46,7 @@
             </ul>
         </nav>
     {% elif this.is_child_of('/community') %}
-        <nav class="filter-menu" aria-labelledby="community">
+        <nav aria-labelledby="community">
             <h2>Community</h2>
             <ul>
                 {% for href, title in [
@@ -87,7 +87,7 @@
             </ul>
         </nav>
     {% elif this.is_child_of('/programs') %}
-        <nav class="filter-menu" aria-labelledby="programs">
+        <nav aria-labelledby="programs">
             <h2>Programs</h2>
             <ul>
                 {% for href, title in [
@@ -117,7 +117,7 @@
             </ul>
         </nav>
     {% endif %}
-    <nav class="filter-menu" aria-labelledby="on-this-page">
+    <nav aria-labelledby="on-this-page">
         <h2>On this page</h2>
         <ul>
             {% for item in this.body.toc %}


### PR DESCRIPTION
## Description
Remove `filter-menu` class from side navigation (collapse spacing between menu items from 2 em to 1 em)

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

## Screenshots

### Old/current

![Screenshot 2025-05-21 at 17-22-29 SaltStack — Creative Commons Open Source](https://github.com/user-attachments/assets/9a851df5-5dd5-41f9-b825-6af3f20d00c4)

### New/pull request

![Screenshot 2025-05-21 at 17-23-04 SaltStack — Creative Commons Open Source](https://github.com/user-attachments/assets/5da6eb8b-fef1-4b17-b935-67e8e10c5e5f)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
