### PR TITLE
update: modified the link’s CSS to improve its color contrast on the …

### DIFF
--- a/assets/static/css/issue-finder.css
+++ b/assets/static/css/issue-finder.css
@@ -71,6 +71,18 @@
   border-color: #0078D4;
 }
 
+/* Fix: Add accessible link style inside issue-finder */
+a {
+  color: var(--vocabulary-brand-color-tomato);
+  text-decoration: underline;
+  transition: color 0.3s ease;
+}
+
+a:hover,
+a:focus {
+  color: #802414;
+  outline: none;
+}
 
 @media (min-width: 1024px) {
 .issue-container {

--- a/assets/static/css/style.css
+++ b/assets/static/css/style.css
@@ -36,10 +36,20 @@
   margin-top: 1.5rem
 }
 
+/* Fix: Added color and underline for hero-description links */
 .hero-description a {
+  color: var(--vocabulary-brand-color-tomato);
   text-transform: uppercase;
   font-size: 1.5rem;
   font-weight: 700;
+  text-decoration: underline;
+  transition: color 0.3s ease;
+}
+
+.hero-description a:hover,
+.hero-description a:focus {
+  color: #802414; /* darker tomato for hover/focus */
+  outline: none;
 }
 
 .home-page main article figure {
@@ -70,7 +80,16 @@
 }
 
 .projects article a {
-    --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
+  --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
+  color: var(--vocabulary-brand-color-tomato);
+  text-decoration: underline;
+  transition: color 0.3s ease;
+}
+
+.projects article a:hover,
+.projects article a:focus {
+  color: #802414;
+  outline: none;
 }
 
 /* Table Styles */
@@ -192,6 +211,14 @@ pre code {
 /* for anchor tags with a span.gh-label inside them */
 main a:has(span.gh-label) {
   --underline-background-color: unset;
+  color: var(--vocabulary-brand-color-tomato); /* fix color here for contrast */
+  text-decoration: underline;
+}
+
+main a:has(span.gh-label):hover,
+main a:has(span.gh-label):focus {
+  color: #802414;
+  outline: none;
 }
 
 /* label style for individual labels */
@@ -317,7 +344,7 @@ main a:has(span.gh-label) {
 }
 
 .step-link {
-  --underline-color: unset
+  --underline-color: unset;
   --underline-background-color: unset;
   color: #333;
   display: flex;


### PR DESCRIPTION
…screen

## Related to #835 by @SumaiyaaRq 

## Description
modified the link’s CSS to improve its color contrast on the screen: added explicit color and underline for all links (a) in CSS files, added hover and focus states with darker colors, specifically updated .hero-description a in styles.css to have better contrast and underline, updated links inside .projects article a and main a:has(span.gh-label) for consistent accessible styles.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
