### PR TITLE
Fix homepage grid alignment by removing inconsistent margins

### DIFF
--- a/assets/static/css/style.css
+++ b/assets/static/css/style.css
@@ -59,7 +59,9 @@
 .projects ul {
   display: grid;
   gap: 2rem;
-  margin-right: 2rem;
+  margin: 0; 
+  padding: 0; 
+  list-style: none;
 }
 
 .projects article {
@@ -380,8 +382,8 @@ main a:has(span.gh-label) {
   .projects {
     grid-column: 2 / 10;
     margin-bottom: 6rem;
+    padding: 0;
   }
-
   .body-container, .main-content{
     grid-column: 2 / 10;
   }


### PR DESCRIPTION
## Fixes
- Fixes #946  by @possumbilities 

## Description
This PR fixes CSS alignment issues in the projects grid layout by removing excessive margin and ensuring consistent padding across different screen sizes.

## Technical details
- Removed `margin-right: 2rem` from `.projects ul` selector
- Added margin/padding reset for flush grid boundaries
- Ensured consistent padding in media queries for mobile responsiveness

## Tests
1. Navigate to the projects page
2. Verify that project items are properly aligned in the grid
3. Test responsiveness on mobile devices to ensure consistent padding
4. Compare with the original issue #946 to confirm the misalignment is resolved

## Screenshots
Problem:
<img width="1168" alt="446143094-ce2ffa69-23f2-4ae9-855b-36fb8ccd337b" src="https://github.com/user-attachments/assets/71a1a342-21cf-4d3f-9965-c1f5ef57eb0e" />
<img width="1208" alt="446143031-389ba68e-3fac-4701-a186-a5997bbf1a1c" src="https://github.com/user-attachments/assets/29923b6c-fc65-409f-9507-62b4a5e19737" />
Solution:
<img width="1512" alt="Screenshot 2025-06-24 at 4 08 29 PM" src="https://github.com/user-attachments/assets/3396c495-0941-46e9-8ee0-e601a250521a" />
<img width="1512" alt="Screenshot 2025-06-24 at 4 08 18 PM" src="https://github.com/user-attachments/assets/12eb1e0d-536e-4b0e-a444-deaf44fd2ac2" />



## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
