### PR TITLE
Fix sidebar visual distinction on contributing-code page

### DIFF
--- a/assets/static/css/style.css
+++ b/assets/static/css/style.css
@@ -278,6 +278,23 @@ main a:has(span.gh-label) {
   color: #000000;
 }
 
+/* Sidebar Visual Distinction */
+main:has( > aside.sidebar) > aside.sidebar {
+    background-color: var(--vocabulary-brand-color-soft-gold);
+    margin-left: 4.1rem;
+    padding: 1em 1em 1em 4.1em;
+    height: fit-content;
+}
+
+main > aside.sidebar nav.filter-menu ul li.current {
+    background: var(--vocabulary-brand-color-dark-tomato);
+    font-weight: bold;
+}
+
+main > aside.sidebar nav.filter-menu ul li.current a {
+    --underline-background-color: var(--vocabulary-brand-color-dark-tomato);
+}
+
 /* CC Search Feature */
 .steps-list {
   list-style: none;

--- a/assets/static/vocabulary/css/vocabulary.css
+++ b/assets/static/vocabulary/css/vocabulary.css
@@ -302,10 +302,7 @@ main:has( > aside.sidebar) > article {
 main:has( > aside.sidebar) > aside.sidebar {
     grid-column: 7 / span 4;
     grid-row-start: 2;
-    background-color: var(--vocabulary-brand-color-soft-gold);
-    margin-left: 4.1rem;
-    padding: 1em 1em 1em 4.1em;
-    height: fit-content;
+    padding-left: 4.1em;
 }
 
 main > aside.sidebar h2 {
@@ -325,13 +322,13 @@ main > aside.sidebar nav.filter-menu ul li {
 }
 
 main > aside.sidebar nav.filter-menu ul li.current {
-    background: var(--vocabulary-brand-color-dark-tomato);
+    background: var(--vocabulary-brand-color-soft-tomato);
     /* padding: 1em; */
     font-weight: bold;
 }
 
 main > aside.sidebar nav.filter-menu ul li.current a {
-    --underline-background-color: var(--vocabulary-brand-color-dark-tomato);
+    --underline-background-color: var(--vocabulary-brand-color-soft-tomato);
 }
 
 main > aside.sidebar nav ul {
@@ -437,7 +434,7 @@ main aside.opening p {
 main a {
      /* better hyperlink underline typesetting inspired by Tufte CSS */
      --underline-color: var(--vocabulary-brand-color-dark-tomato);
-     /* --underline-background-color: white; */
+     --underline-background-color: white;
      color: var(--vocabulary-brand-color-dark-tomato);
      text-decoration: none;
 

--- a/assets/static/vocabulary/css/vocabulary.css
+++ b/assets/static/vocabulary/css/vocabulary.css
@@ -302,7 +302,10 @@ main:has( > aside.sidebar) > article {
 main:has( > aside.sidebar) > aside.sidebar {
     grid-column: 7 / span 4;
     grid-row-start: 2;
-    padding-left: 4.1em;
+    background-color: var(--vocabulary-brand-color-soft-gold);
+    margin-left: 4.1rem;
+    padding: 1em 1em 1em 4.1em;
+    height: fit-content;
 }
 
 main > aside.sidebar h2 {
@@ -322,13 +325,13 @@ main > aside.sidebar nav.filter-menu ul li {
 }
 
 main > aside.sidebar nav.filter-menu ul li.current {
-    background: var(--vocabulary-brand-color-soft-tomato);
+    background: var(--vocabulary-brand-color-dark-tomato);
     /* padding: 1em; */
     font-weight: bold;
 }
 
 main > aside.sidebar nav.filter-menu ul li.current a {
-    --underline-background-color: var(--vocabulary-brand-color-soft-tomato);
+    --underline-background-color: var(--vocabulary-brand-color-dark-tomato);
 }
 
 main > aside.sidebar nav ul {
@@ -434,7 +437,7 @@ main aside.opening p {
 main a {
      /* better hyperlink underline typesetting inspired by Tufte CSS */
      --underline-color: var(--vocabulary-brand-color-dark-tomato);
-     --underline-background-color: white;
+     /* --underline-background-color: white; */
      color: var(--vocabulary-brand-color-dark-tomato);
      text-decoration: none;
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #943  by @possumbilities 

## Description
<!-- Concisely describe what the pull request does. -->
Fixes sidebar visual distinction issue on contributing pages by adding background styling and improved spacing to match the design consistency used in legal tools pages.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
- Added `var(--vocabulary-brand-color-soft-gold)` background color to sidebar container
- Applied consistent `1em` padding and `4.1rem` left margin for proper spacing  
- Set `height: fit-content` to ensure sidebar scales appropriately with content
- Removed excessive `padding-left: 4.1em` that was causing layout issues
- **Fixed link visibility by removing white underline background that was masking text on gold background**

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
1. Navigate to any Contributing Code page (e.g., `/contributing-code/`)
2. Verify sidebar now has a light gold background that clearly separates it from main content
3. Check that sidebar content is properly contained within the background area
4. Compare with legal tools pages to confirm visual consistency

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
Problem:
<img width="1145" height="658" alt="446132484-fd17dd07-ae44-4499-acff-72addf2dd175" src="https://github.com/user-attachments/assets/11a68ba4-9181-4dac-9b5a-4fe4472b1a48" />
Solution:
<img width="1510" height="823" alt="Screenshot 2025-07-29 at 3 03 01 PM" src="https://github.com/user-attachments/assets/d6703e1c-84ad-4551-8404-93bbfc4689f5" />

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
